### PR TITLE
feat(home, api): ユーザー情報取得APIを追加し、/homeでDB由来の画像・名前をピンに反映

### DIFF
--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+// GET /api/users?email=xxx@example.com
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const email = searchParams.get('email');
+
+  if (!email) {
+    return NextResponse.json({ error: 'email is required' }, { status: 400 });
+  }
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: { email },
+      select: {
+        id: true,
+        name: true,
+        image: true,
+        email: true,
+      },
+    });
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(user);
+  } catch (error) {
+    console.error('DB query failed:', error);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## 📝 概要

- 新規: /api/users?email=xxx でUser情報を取得できるAPIを追加
- homeページでcurrentUserEmailからUser情報をfetchしピンに反映
- mapロード時のflyTo挙動を安定化
- 現在地をlocalStorageに保持して再アクセス時に復元

---

## ✅ 動作確認

・/homeアクセス時に仮ユーザのピンを表示すること
・/homeページでDB由来のユーザー画像と名前を使用

---

## 💬 次回以降の作業
「ユーザー詳細ページの新規作成」＋「Popup押下で遷移」


